### PR TITLE
Add cloudbuild configuration

### DIFF
--- a/foo-corp/cloudbuild.yaml
+++ b/foo-corp/cloudbuild.yaml
@@ -1,0 +1,19 @@
+steps:
+- name: 'gcr.io/cloud-builders/kubectl'
+  args: ['config', 'current-context']
+  volumes:
+  - name: 'kube'
+    path: '/kube'
+  env:
+  - 'KUBECONFIG=/kube/config'
+  - 'CLOUDSDK_COMPUTE_ZONE=us-central1-a'
+  - 'CLOUDSDK_CONTAINER_CLUSTER=demo-cluster-1'
+  - 'CLOUDSDK_CONTAINER_USE_APPLICATION_DEFAULT_CREDENTIALS=true'
+- name: 'gcr.io/config-management-release/nomos:stable'
+  args: ['nomos', 'vet', '--path', '/workspace']
+  volumes:
+  - name: 'kube'
+    path: '/kube'
+  env:
+  - 'KUBECONFIG=/kube/config'
+  timeout: 30s


### PR DESCRIPTION
Follow https://cloud.google.com/anthos-config-management/docs/how-to/validating-configs.
Our new Google Cloud Build trigger will depend on this configuration file.