### PR TITLE
Add step to cloudbuild to help debug permissions

### DIFF
--- a/foo-corp/cloudbuild.yaml
+++ b/foo-corp/cloudbuild.yaml
@@ -9,6 +9,8 @@ steps:
   - 'CLOUDSDK_COMPUTE_ZONE=us-central1-a'
   - 'CLOUDSDK_CONTAINER_CLUSTER=demo-cluster-1'
   - 'CLOUDSDK_CONTAINER_USE_APPLICATION_DEFAULT_CREDENTIALS=true'
+- name: 'bash'
+  args: ['ls', '-al', '/kube']
 - name: 'gcr.io/config-management-release/nomos:stable'
   args: ['nomos', 'vet', '--path', '/workspace']
   volumes:


### PR DESCRIPTION
Add step to cloudbuild to help debug permissions
Will be used to debug the following error: [1] KNV2002: could not get discovery client: Error loading config file "/kube/config": open /kube/config: permission denied