### PR TITLE
Fix indentation in cloudbuild

### DIFF
--- a/foo-corp/cloudbuild.yaml
+++ b/foo-corp/cloudbuild.yaml
@@ -1,27 +1,19 @@
 steps:
-- name: 'bash'
-  args: ['pwd']
-- name: 'bash'
-  args: ['cd', '~']
-- name: 'bash'
-  args: ['pwd']
 - name: 'gcr.io/cloud-builders/kubectl'
   args: ['config', 'current-context']
   volumes:
-  - name: 'kube'
-    path: '/.kube'
+    - name: 'kube'
+      path: '/kube'
   env:
-  - 'KUBECONFIG=/.kube/config'
-  - 'CLOUDSDK_COMPUTE_ZONE=us-central1-a'
-  - 'CLOUDSDK_CONTAINER_CLUSTER=demo-cluster-1'
-  - 'CLOUDSDK_CONTAINER_USE_APPLICATION_DEFAULT_CREDENTIALS=true'
-- name: 'bash'
-  args: ['ls', '-al', '/.kube']
-- name: 'gcr.io/config-management-release/nomos:stable'
+    - 'KUBECONFIG=/kube/config'
+    - 'CLOUDSDK_COMPUTE_ZONE=us-central1-a'
+    - 'CLOUDSDK_CONTAINER_CLUSTER=test'
+    - 'CLOUDSDK_CONTAINER_USE_APPLICATION_DEFAULT_CREDENTIALS=true'
+- name: 'gcr.io/nomos-release/nomos:stable'
   args: ['nomos', 'vet', '--path', '/workspace']
   volumes:
   - name: 'kube'
-    path: '/.kube'
+    path: '/kube'
   env:
-  - 'KUBECONFIG=/.kube/config'
+    - 'KUBECONFIG=/kube/config'
   timeout: 30s


### PR DESCRIPTION
It may not know to set environment variables if they're not properly indented.